### PR TITLE
Pretty-print precedence for Negate fixed

### DIFF
--- a/src/calc/syntax.ml
+++ b/src/calc/syntax.ml
@@ -14,7 +14,7 @@ let string_of_expression e =
   let rec to_str n e =
     let (m, str) = match e with
 	Numeral n       ->    (3, string_of_int n)
-      | Negate e        ->    (2, "-" ^ (to_str 0 e))
+      | Negate e        ->    (2, "-" ^ (to_str 2 e))
       | Times (e1, e2)  ->    (1, (to_str 1 e1) ^ " * " ^ (to_str 2 e2))
       | Divide (e1, e2) ->    (1, (to_str 1 e1) ^ " / " ^ (to_str 2 e2))
       | Plus (e1, e2)   ->    (0, (to_str 0 e1) ^ " + " ^ (to_str 1 e2))

--- a/src/calc_var/syntax.ml
+++ b/src/calc_var/syntax.ml
@@ -21,7 +21,7 @@ let string_of_expression e =
     let (m, str) = match e with
       | Variable x      ->    (3, x)
       | Numeral n       ->    (3, string_of_int n)
-      | Negate e        ->    (2, "-" ^ (to_str 0 e))
+      | Negate e        ->    (2, "-" ^ (to_str 2 e))
       | Times (e1, e2)  ->    (1, (to_str 1 e1) ^ " * " ^ (to_str 2 e2))
       | Divide (e1, e2) ->    (1, (to_str 1 e1) ^ " / " ^ (to_str 2 e2))
       | Plus (e1, e2)   ->    (0, (to_str 0 e1) ^ " + " ^ (to_str 1 e2))


### PR DESCRIPTION
Without the fix the following is true

```OCaml
string_of_expression @@ Negate (Plus (Number 1, Number 2)) = "-1 + 2"
```