### PR TITLE
Fixed type pretty-printing in Levy

### DIFF
--- a/src/levy/README.md
+++ b/src/levy/README.md
@@ -31,7 +31,7 @@ function. You can load it and try it as follows:
     val a : int = 5
     val b : int = 15
     val c : U (F int) = <thunk>
-    val fact : U int -> F int = <thunk>
+    val fact : U (int -> F int) = <thunk>
     return (5040) : F int
     levy -- programming languages zoo
     Type Ctrl-D to exit

--- a/src/levy/type_check.ml
+++ b/src/levy/type_check.ml
@@ -27,10 +27,10 @@ and print_ctype ?max_level cty ppf =
                       "F@ %t" 
                       (print_vtype ~max_level:1 vty)
   | CArrow (vty, cty) ->
-     Zoo.print_parens ?max_level ~at_level:1 ppf
+     Zoo.print_parens ?max_level ~at_level:3 ppf
                       "%t@ ->@ %t"
-                      (print_vtype ~max_level:1 vty)
-                      (print_ctype ~max_level:2 cty)
+                      (print_vtype ~max_level:2 vty)
+                      (print_ctype ~max_level:3 cty)
 
 let rec as_ctype {Zoo.data=ty; loc} =
   match ty with


### PR DESCRIPTION
It looks like the pretty-printing code in Levy omits the parentheses for types like U (A -> B) and prints superfluous ones for types like U A -> B. I don't have a working OCaml environment at the moment to confirm and test, but I believe this is a fix.