### PR TITLE
Fix typo: characters.

### DIFF
--- a/src/zoo/zoo.ml
+++ b/src/zoo/zoo.ml
@@ -49,7 +49,7 @@ let print_location loc ppf =
       let filename = begin_pos.Lexing.pos_fname in
 
       if String.length filename != 0 then
-        Format.fprintf ppf "file %S, line %d, charaters %d-%d" filename begin_line begin_char end_char
+        Format.fprintf ppf "file %S, line %d, characters %d-%d" filename begin_line begin_char end_char
       else
         Format.fprintf ppf "line %d, characters %d-%d" (begin_line - 1) begin_char end_char
 


### PR DESCRIPTION
I noticed that "characters" is misspelled in the message for syntax errors within files. 